### PR TITLE
Fix darkened texture output in GTFO VR

### DIFF
--- a/src/openvr/openvr_manager.cpp
+++ b/src/openvr/openvr_manager.cpp
@@ -23,11 +23,14 @@ namespace vrperfkit {
 			switch (inputFormat) {
 			case DXGI_FORMAT_R10G10B10A2_UNORM:
 			case DXGI_FORMAT_R10G10B10A2_TYPELESS:
-			case DXGI_FORMAT_R16G16B16A16_TYPELESS:
 				// SteamVR applies a different color conversion for these formats that we can't match
 				// with R8G8B8 textures, so we have to use a matching texture format for our own resources.
 				// Otherwise we'll get darkened pictures (applies to Revive mostly)
 				return DXGI_FORMAT_R10G10B10A2_UNORM;
+			case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+				// Same as above, for GTFO VR mod. 
+				// Oculus HMDs will return TextureUsesUnsupportedFormat if DXGI_FORMAT_R10G10B10A2_UNORM is used for this case.
+				return DXGI_FORMAT_R16G16B16A16_FLOAT;
 			default:
 				return DXGI_FORMAT_R8G8B8A8_UNORM;
 			}

--- a/src/openvr/openvr_manager.cpp
+++ b/src/openvr/openvr_manager.cpp
@@ -23,6 +23,7 @@ namespace vrperfkit {
 			switch (inputFormat) {
 			case DXGI_FORMAT_R10G10B10A2_UNORM:
 			case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+			case DXGI_FORMAT_R16G16B16A16_TYPELESS:
 				// SteamVR applies a different color conversion for these formats that we can't match
 				// with R8G8B8 textures, so we have to use a matching texture format for our own resources.
 				// Otherwise we'll get darkened pictures (applies to Revive mostly)


### PR DESCRIPTION
In GTFO VR, we use an ancient version of OpenVR/SteamVR and/or the devs prefer to use full float targets, so we end up with an exotic texture input format -DXGI_FORMAT_R16G16B16A16_TYPELESS

If using VRPerfkit, this resulted in a darkened output.
If we handle this case too and use the 10/10/10/2 output format, we get results identical to the native output.